### PR TITLE
Merge rmc50/front end home styling to rmc50/front_end_home

### DIFF
--- a/front-end/src/App.js
+++ b/front-end/src/App.js
@@ -2,7 +2,10 @@ import React, { Component } from 'react';
 import './App.css';
 import Home from './home';
 import Devices from './devices';
+import Paper from '@material-ui/core/Paper';
+import { styles, theme } from './styling'
 import { MuiThemeProvider} from '@material-ui/core/styles';
+
 
 
 
@@ -21,15 +24,16 @@ class App extends Component {
 
   render() {
     return (
-        <MuiThemeProvider>
-            <div className={"App-header"}>
-                Welcome to the client application for the DASHR
-            </div>
-            <div className={"App"}>
+        <MuiThemeProvider theme={theme}>
+            <div style={styles.backgroundStyle}>
+                <div style={styles.headerStyle}>
+                    Welcome to the client application for the DASHR
+                </div>
+                <Paper style={styles.paperStyle}>
                 {
                     (this.state.homeView) ? <Home view={this.changeView}/> : <Devices/>
                 }
-
+                </Paper>
 
             </div>
         </MuiThemeProvider>

--- a/front-end/src/devices.js
+++ b/front-end/src/devices.js
@@ -1,10 +1,11 @@
 import React, { Component } from 'react';
+import { styles } from './styling'
 
 class Devices extends Component {
 
     render(){
         return(
-            <div>
+            <div style={styles.viewStyle}>
                 this is new view - the list of devices will go here!
             </div>
         )

--- a/front-end/src/home.js
+++ b/front-end/src/home.js
@@ -43,7 +43,6 @@ class Home extends Component {
                 <Button
                     style={styles.connectButtonStyle}
                     variant="raised"
-                    color={"primary"}
                     onClick={this.connectDevices}
                     label={"Connect to Devices"}
                     >

--- a/front-end/src/home.js
+++ b/front-end/src/home.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import Button from '@material-ui/core/Button';
 import axios from 'axios';
+import { styles } from './styling'
 import ErrorMessage from './error';
 
 
@@ -38,11 +39,13 @@ class Home extends Component {
 
     render(){
         return (
-            <div className="home-button">
+            <div style={styles.viewStyle}>
                 <Button
+                    style={styles.connectButtonStyle}
                     variant="raised"
                     color={"primary"}
                     onClick={this.connectDevices}
+                    label={"Connect to Devices"}
                     >
                     Connect to Devices
                 </Button>

--- a/front-end/src/styling.js
+++ b/front-end/src/styling.js
@@ -1,0 +1,45 @@
+import { MuiThemeProvider, createMuiTheme } from '@material-ui/core/styles';
+
+export const theme = createMuiTheme({
+  palette: {
+      type:'light',
+  },
+  typography: {
+    // Use the system font instead of the default Roboto font.
+    fontFamily: [
+      'sans-serif',
+    ].join(','),
+  },
+});
+
+
+export var styles = {
+    "backgroundStyle":{
+        "backgroundColor": "#F1F1F1",
+        "text-align": "center",
+        "height": "100vh"
+
+    },
+    "headerStyle": {
+        "backgroundColor": "#282c34",
+        "font-size": "2vh",
+        "color": "white",
+        "padding": "2.5vh",
+    },
+    "paperStyle": {
+        "height": "75vh",
+        "width": "75vh",
+        "marginTop": "5vh",
+        "display": "inline-block",
+        "backgroundColor": "#f9f9f9",
+
+    },
+    "viewStyle": {
+        "marginTop": "20vh",
+        "font-size": "2vh",
+    },
+    "connectButtonStyle": {
+        "font-size": "2vh"
+    }
+
+}

--- a/front-end/src/styling.js
+++ b/front-end/src/styling.js
@@ -2,7 +2,10 @@ import { MuiThemeProvider, createMuiTheme } from '@material-ui/core/styles';
 
 export const theme = createMuiTheme({
   palette: {
-      type:'light',
+      primary: {
+      main: '#232F34',
+    },
+    secondary: {main: "#03DAC5"}
   },
   typography: {
     // Use the system font instead of the default Roboto font.
@@ -15,23 +18,23 @@ export const theme = createMuiTheme({
 
 export var styles = {
     "backgroundStyle":{
-        "backgroundColor": "#F1F1F1",
         "text-align": "center",
-        "height": "100vh"
+        "height": "100vh",
+        "backgroundColor":"#344955"
 
     },
     "headerStyle": {
-        "backgroundColor": "#282c34",
         "font-size": "2vh",
         "color": "white",
         "padding": "2.5vh",
+        "backgroundColor":"#232F34"
     },
     "paperStyle": {
         "height": "75vh",
         "width": "75vh",
         "marginTop": "5vh",
         "display": "inline-block",
-        "backgroundColor": "#f9f9f9",
+        "backgroundColor":"#344955",
 
     },
     "viewStyle": {
@@ -39,7 +42,9 @@ export var styles = {
         "font-size": "2vh",
     },
     "connectButtonStyle": {
-        "font-size": "2vh"
+        "font-size": "3vh",
+        "backgroundColor":"#03DAC5"
+
     }
 
 }


### PR DESCRIPTION
Implemented styling theme
<img width="695" alt="screen shot 2018-12-09 at 11 39 46 pm" src="https://user-images.githubusercontent.com/37776293/49711169-e6186b80-fc0b-11e8-8ef3-ed4596774429.png">
